### PR TITLE
Increase rpc timeout and downgrade get/read errors to debug

### DIFF
--- a/apteryx.c
+++ b/apteryx.c
@@ -522,7 +522,7 @@ handle_get_response (const Apteryx__GetResult *result, void *closure_data)
     get_data_t *data = (get_data_t *)closure_data;
     if (result == NULL)
     {
-        ERROR ("GET: Error processing request.\n");
+        DEBUG ("GET: Error processing request.\n");
     }
     else if (result->value && result->value[0] != '\0')
     {

--- a/apteryxd.c
+++ b/apteryxd.c
@@ -417,7 +417,7 @@ handle_get_response (const Apteryx__GetResult *result, void *closure_data)
     get_data_t *data = (get_data_t *)closure_data;
     if (result == NULL)
     {
-        ERROR ("GET: Error processing request.\n");
+        DEBUG ("GET: Error processing request.\n");
     }
     else if (result->value && result->value[0] != '\0')
     {

--- a/internal.h
+++ b/internal.h
@@ -126,7 +126,7 @@ bool db_get (const char *path, unsigned char **value, size_t *length);
 GList *db_search (const char *path);
 
 /* RPC API */
-#define RPC_TIMEOUT_US 1000000
+#define RPC_TIMEOUT_US 2000000
 bool rpc_provide_service (const char *name, ProtobufCService *service, int num_threads, int stopfd);
 ProtobufCService *rpc_connect_service (const char *name, const ProtobufCServiceDescriptor *descriptor);
 

--- a/rpc.c
+++ b/rpc.c
@@ -582,7 +582,7 @@ invoke_client_service (ProtobufCService *service,
         }
         else if ((get_time_us () - start) > RPC_TIMEOUT_US)
         {
-            ERROR ("RPC[%d]: read() timeout\n", client->fd);
+            DEBUG ("RPC[%d]: read() timeout\n", client->fd);
             goto error;
         }
         else if (rv < 0)


### PR DESCRIPTION
In some cases 1s wasn't long enough to get a response,
also making this timeout an error is aggressive.