### PR TITLE
Add the ability to determine timestamp of path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ CFLAGS := $(CFLAGS) -g -O2
 EXTRA_CFLAGS += -Wall -Wno-comment -std=c99 -D_GNU_SOURCE -fPIC
 EXTRA_CFLAGS += -I. -I/usr/include/google `$(PKG_CONFIG) --cflags glib-2.0`
 EXTRA_LDFLAGS := `$(PKG_CONFIG) --libs glib-2.0` -lpthread
-EXTRA_LDFLAGS += -lprotobuf-c
+EXTRA_LDFLAGS += -lrt -lprotobuf-c
 ifneq ($(HAVE_LUA),no)
 EXTRA_CFLAGS += -DHAVE_LUA `$(PKG_CONFIG) --exists lua && $(PKG_CONFIG) --cflags lua || $(PKG_CONFIG) --cflags lua5.2`
 EXTRA_LDFLAGS += `$(PKG_CONFIG) --exists lua && $(PKG_CONFIG) --libs lua || $(PKG_CONFIG) --libs lua5.2`

--- a/apteryx.h
+++ b/apteryx.h
@@ -182,4 +182,11 @@ typedef char* (*apteryx_provide_callback) (const char *path, void *priv);
  */
 bool apteryx_provide (const char *path, apteryx_provide_callback cb, void *priv);
 
+
+/**
+ * Get the last change timestamp of a given path
+ * @param path path to get the timestamp for
+ * @return 0 if the path doesn't exist, last change timestamp otherwise
+ */
+uint64_t apteryx_get_timestamp (const char *path);
 #endif /* _APTERYX_H_ */

--- a/apteryx.proto
+++ b/apteryx.proto
@@ -52,6 +52,11 @@ message Prune
     required string path = 1;
 };
 
+message GetTimeStampResult
+{
+    required uint64 value = 1;
+};
+
 service server
 {
     rpc set (Set) returns (OKResult);
@@ -60,6 +65,7 @@ service server
     rpc watch (Watch) returns (OKResult);
     rpc provide (Provide) returns (OKResult);
     rpc prune (Prune) returns (OKResult);
+    rpc get_timestamp (Get) returns (GetTimeStampResult);
 }
 
 service client

--- a/apteryxd.c
+++ b/apteryxd.c
@@ -825,6 +825,36 @@ apteryx__prune (Apteryx__Server_Service *service,
     return;
 }
 
+static void
+apteryx__get_timestamp (Apteryx__Server_Service *service,
+                        const Apteryx__Get *get,
+                        Apteryx__GetTimeStampResult_Closure closure, void *closure_data)
+{
+    Apteryx__GetTimeStampResult result = APTERYX__GET_TIME_STAMP_RESULT__INIT;
+    uint64_t value = 0;
+
+    /* Check parameters */
+    if (get == NULL || get->path == NULL)
+    {
+        ERROR ("GET: Invalid parameters.\n");
+        closure (NULL, closure_data);
+        INC_COUNTER (counters.get_invalid);
+        return;
+    }
+    INC_COUNTER (counters.get);
+
+    DEBUG ("GET: %s\n", get->path);
+
+    /* Lookup value */
+    value = db_get_timestamp (get->path);
+
+    /* Send result */
+    DEBUG ("     = %"PRIu64"\n", value);
+    result.value = value;
+    closure (&result, closure_data);
+    return;
+}
+
 static Apteryx__Server_Service apteryx_service = APTERYX__SERVER__INIT (apteryx__);
 
 void

--- a/database.c
+++ b/database.c
@@ -37,10 +37,26 @@ struct database_node
     struct database_node *parent;
     GHashTable *children;
     unsigned int removing;
+    uint64_t timestamp;
+    uint64_t timestamp_max;
 };
 struct database_node *root = NULL;  /* The database root */
 
 static pthread_rwlock_t db_lock = PTHREAD_RWLOCK_INITIALIZER;
+
+static uint64_t
+db_calculate_timestamp (void)
+{
+    struct timespec tms;
+    uint64_t micros = 0;
+    if (clock_gettime(CLOCK_REALTIME,&tms)) {
+        return 0;
+    }
+
+    micros = tms.tv_sec * 1000000;
+    micros += tms.tv_nsec/1000;
+    return micros;
+}
 
 static char *
 db_node_to_path (struct database_node *node, char **buf)
@@ -220,6 +236,43 @@ db_parent_get (const char *path)
     return node;
 }
 
+static void
+db_update_parent_timestamp (const char *path, uint64_t timestamp)
+{
+    struct database_node *node = NULL;
+    char *parent = strdup (path);
+    if (strlen (parent) == 0)
+    {
+        /* found the root node */
+        node = root;
+    }
+    else
+    {
+        if (strchr (parent, '/') != NULL)
+            *strrchr (parent, '/') = '\0';
+
+        node = db_path_to_node (parent);
+    }
+    if (node)
+    {
+        node->timestamp_max = timestamp;
+        if (node != root)
+        {
+            db_update_parent_timestamp (parent, timestamp);
+        }
+    }
+    free (parent);
+}
+
+uint64_t
+db_get_timestamp (const char *path)
+{
+    struct database_node *new_value = db_path_to_node (path);
+    if (new_value)
+        return new_value->timestamp_max;
+    return 0;
+}
+
 bool
 db_add (const char *path, const unsigned char *value, size_t length)
 {
@@ -247,6 +300,9 @@ db_add (const char *path, const unsigned char *value, size_t length)
         memcpy (new_value->value, value, length);
     }
     new_value->length = length;
+    new_value->timestamp = db_calculate_timestamp ();
+    new_value->timestamp_max = new_value->timestamp;
+    db_update_parent_timestamp (path, new_value->timestamp);
     pthread_rwlock_unlock (&db_lock);
     return true;
 }
@@ -255,6 +311,7 @@ bool
 db_delete (const char *path)
 {
     pthread_rwlock_wrlock (&db_lock);
+    db_update_parent_timestamp (path, db_calculate_timestamp ());
     struct database_node *node = db_path_to_node (path);
     if (node)
         db_node_delete (node);
@@ -563,6 +620,34 @@ test_db_search_perf ()
     db_shutdown ();
 }
 
+void
+test_db_timestamping ()
+{
+    char *path = "/test/timestamps";
+    char *path2 = "/test/timestamp2";
+    char *ppath = "/test";
+
+    uint64_t last_ts;
+
+    db_init ();
+
+    CU_ASSERT (db_add (path, (const unsigned char *) "test", 5));
+    last_ts = db_get_timestamp (path);
+    sleep (1);
+    CU_ASSERT (db_add (path2, (const unsigned char *) "test", 5));
+    CU_ASSERT (db_get_timestamp (path2) > last_ts);
+    last_ts = db_get_timestamp (path2);
+    CU_ASSERT (db_get_timestamp (path) < db_get_timestamp (path2));
+    CU_ASSERT (db_get_timestamp (ppath) == db_get_timestamp (path2));
+
+    CU_ASSERT (db_delete (path2));
+    CU_ASSERT (db_get_timestamp (ppath) > last_ts);
+
+    CU_ASSERT (db_delete (path));
+
+    db_shutdown ();
+}
+
 CU_TestInfo tests_database_internal[] = {
     { "delete", test_db_internal_delete },
     { "node_to_path", test_db_node_to_path },
@@ -580,6 +665,7 @@ CU_TestInfo tests_database[] = {
     { "replace", test_db_replace },
     { "search", test_db_search },
     { "search performance", test_db_search_perf },
+    { "timestamping", test_db_timestamping },
     CU_TEST_INFO_NULL,
 };
 #endif

--- a/internal.h
+++ b/internal.h
@@ -127,6 +127,7 @@ bool db_add (const char *path, const unsigned char *value, size_t length);
 bool db_delete (const char *path);
 bool db_get (const char *path, unsigned char **value, size_t *length);
 GList *db_search (const char *path);
+uint64_t db_get_timestamp (const char *path);
 
 /* RPC API */
 #define RPC_TIMEOUT_US 1000000

--- a/test.c
+++ b/test.c
@@ -1201,6 +1201,7 @@ test_deadlock ()
         CU_ASSERT (asprintf(&path, "/entity/zones/private/state/%d", i) > 0);
         CU_ASSERT (apteryx_set (path, "set"));
         CU_ASSERT (apteryx_watch (path, test_deadlock_callback, (void *) 0x12345678));
+        free (path);
     }
     CU_ASSERT (apteryx_prune("/"));
     usleep(1000);
@@ -1212,6 +1213,7 @@ test_deadlock ()
         char *path = NULL;
         CU_ASSERT (asprintf(&path, "/entity/zones/private/state/%d", i) > 0);
         CU_ASSERT (apteryx_watch (path, NULL, NULL));
+        free (path);
     }
     CU_ASSERT (apteryx_prune("/"));
 }
@@ -1234,6 +1236,7 @@ test_deadlock2 ()
         CU_ASSERT (asprintf(&path, "/entity/zones/private/state/%d", i) > 0);
         CU_ASSERT (apteryx_set (path, "set"));
         CU_ASSERT (apteryx_watch (path, test_deadlock2_callback, (void *) 0x12345678));
+        free (path);
     }
     CU_ASSERT (apteryx_prune("/"));
     usleep(200);
@@ -1245,6 +1248,7 @@ test_deadlock2 ()
         char *path = NULL;
         CU_ASSERT (asprintf(&path, "/entity/zones/private/state/%d", i) > 0);
         CU_ASSERT (apteryx_watch (path, NULL, NULL));
+        free (path);
     }
     CU_ASSERT (apteryx_prune("/"));
 }


### PR DESCRIPTION
Also, stop leaking memory in test cases that produce dynamic paths