### PR TITLE
Add the ability to determine timestamp of path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ CFLAGS := $(CFLAGS) -g -O2
 EXTRA_CFLAGS += -Wall -Wno-comment -std=c99 -D_GNU_SOURCE -fPIC
 EXTRA_CFLAGS += -I. -I/usr/include/google `$(PKG_CONFIG) --cflags glib-2.0`
 EXTRA_LDFLAGS := `$(PKG_CONFIG) --libs glib-2.0` -lpthread
-EXTRA_LDFLAGS += -lprotobuf-c
+EXTRA_LDFLAGS += -lrt -lprotobuf-c
 ifneq ($(HAVE_LUA),no)
 EXTRA_CFLAGS += -DHAVE_LUA `$(PKG_CONFIG) --exists lua && $(PKG_CONFIG) --cflags lua || $(PKG_CONFIG) --cflags lua5.2`
 EXTRA_LDFLAGS += `$(PKG_CONFIG) --exists lua && $(PKG_CONFIG) --libs lua || $(PKG_CONFIG) --libs lua5.2`

--- a/apteryx.h
+++ b/apteryx.h
@@ -182,4 +182,11 @@ typedef char* (*apteryx_provide_callback) (const char *path, void *priv);
  */
 bool apteryx_provide (const char *path, apteryx_provide_callback cb, void *priv);
 
+
+/**
+ * Get the last change timestamp of a given path
+ * @param path path to get the timestamp for
+ * @return 0 if the path doesn't exist, last change timestamp otherwise
+ */
+uint64_t apteryx_get_timestamp (const char *path);
 #endif /* _APTERYX_H_ */

--- a/apteryx.proto
+++ b/apteryx.proto
@@ -52,6 +52,11 @@ message Prune
     required string path = 1;
 };
 
+message GetTimeStampResult
+{
+    required uint64 value = 1;
+};
+
 service server
 {
     rpc set (Set) returns (OKResult);
@@ -60,6 +65,7 @@ service server
     rpc watch (Watch) returns (OKResult);
     rpc provide (Provide) returns (OKResult);
     rpc prune (Prune) returns (OKResult);
+    rpc get_timestamp (Get) returns (GetTimeStampResult);
 }
 
 service client

--- a/apteryxc.c
+++ b/apteryxc.c
@@ -44,7 +44,7 @@ termination_handler (void)
 void
 usage ()
 {
-    printf ("Usage: apteryx [-h] [-s|-g|-f|-t|-w|-p] [<path>] [<value>]\n"
+    printf ("Usage: apteryx [-h] [-s|-g|-f|-t|-w|-p|-l] [<path>] [<value>]\n"
             "  -h   show this help\n"
             "  -d   debug\n"
             "  -s   set <path>=<value>\n"
@@ -52,7 +52,8 @@ usage ()
             "  -f   find <path>\n"
             "  -t   traverse database from <path>\n"
             "  -w   watch changes to the path <path>\n"
-            "  -p   provide <value> for <path>\n");
+            "  -p   provide <value> for <path>\n"
+            "  -l   last change <path>\n");
     printf ("\n");
     printf ("  Internal settings\n");
     printf ("    %sdebug\n", APTERYX_SETTINGS);
@@ -85,6 +86,7 @@ main (int argc, char **argv)
     char *param = NULL;
     GList * _iter;
     int c;
+    uint64_t value;
 
     /* Handle SIGTERM/SIGINT/SIGPIPE gracefully */
     signal (SIGTERM, (__sighandler_t) termination_handler);
@@ -115,6 +117,9 @@ main (int argc, char **argv)
             break;
         case 'p':
             mode = MODE_PROVIDE;
+            break;
+        case 'l':
+            mode = MODE_TIMESTAMP;
             break;
         case '?':
         case 'h':
@@ -221,6 +226,17 @@ main (int argc, char **argv)
         while (running)
             pause ();
         apteryx_provide (path, NULL, NULL);
+        apteryx_shutdown ();
+        break;
+    case MODE_TIMESTAMP:
+        if (!path || param)
+        {
+            usage ();
+            return 0;
+        }
+        apteryx_init (debug);
+        value = apteryx_get_timestamp (path);
+        printf ("%"PRIu64"\n", value);
         apteryx_shutdown ();
         break;
     default:

--- a/internal.h
+++ b/internal.h
@@ -45,6 +45,7 @@ typedef enum
     MODE_WATCH,
     MODE_PROVIDE,
     MODE_PRUNE,
+    MODE_TIMESTAMP,
 } APTERYX_MODE;
 
 /* Debug */
@@ -117,6 +118,8 @@ typedef struct _counters_t
     uint32_t provided_no_handler;
     uint32_t prune;
     uint32_t prune_invalid;
+    uint32_t get_ts;
+    uint32_t get_ts_invalid;
 } counters_t;
 #define INC_COUNTER(c) (void)g_atomic_int_inc(&c);
 
@@ -127,6 +130,7 @@ bool db_add (const char *path, const unsigned char *value, size_t length);
 bool db_delete (const char *path);
 bool db_get (const char *path, unsigned char **value, size_t *length);
 GList *db_search (const char *path);
+uint64_t db_get_timestamp (const char *path);
 
 /* RPC API */
 #define RPC_TIMEOUT_US 1000000

--- a/test.c
+++ b/test.c
@@ -1201,6 +1201,7 @@ test_deadlock ()
         CU_ASSERT (asprintf(&path, "/entity/zones/private/state/%d", i) > 0);
         CU_ASSERT (apteryx_set (path, "set"));
         CU_ASSERT (apteryx_watch (path, test_deadlock_callback, (void *) 0x12345678));
+        free (path);
     }
     CU_ASSERT (apteryx_prune("/"));
     usleep(1000);
@@ -1212,6 +1213,7 @@ test_deadlock ()
         char *path = NULL;
         CU_ASSERT (asprintf(&path, "/entity/zones/private/state/%d", i) > 0);
         CU_ASSERT (apteryx_watch (path, NULL, NULL));
+        free (path);
     }
     CU_ASSERT (apteryx_prune("/"));
 }
@@ -1234,6 +1236,7 @@ test_deadlock2 ()
         CU_ASSERT (asprintf(&path, "/entity/zones/private/state/%d", i) > 0);
         CU_ASSERT (apteryx_set (path, "set"));
         CU_ASSERT (apteryx_watch (path, test_deadlock2_callback, (void *) 0x12345678));
+        free (path);
     }
     CU_ASSERT (apteryx_prune("/"));
     usleep(200);
@@ -1245,6 +1248,7 @@ test_deadlock2 ()
         char *path = NULL;
         CU_ASSERT (asprintf(&path, "/entity/zones/private/state/%d", i) > 0);
         CU_ASSERT (apteryx_watch (path, NULL, NULL));
+        free (path);
     }
     CU_ASSERT (apteryx_prune("/"));
 }


### PR DESCRIPTION
The timestamp on each db node is updated each time it,
or one of its' (*grand)children is updated.
Once the rwlock is released on the database, the root will have
the highest (equal) timestamp in the tree, and no node will
have a timestamp higher than it's parent

Also:
- add support to apteryx client (-l, last-change)
- update counters
- added tests to verify root >= parent >= child
- stop leaking memory in test cases that produce dynamic paths