### PR TITLE
Watch/Provide cb tuples now include callback function in unique key

### DIFF
--- a/apteryx.h
+++ b/apteryx.h
@@ -158,7 +158,21 @@ typedef bool (*apteryx_watch_callback) (const char *path, void *priv, const char
  * @param priv something I want to be passed to my callback
  * @return true on successful registration
  */
-bool apteryx_watch (const char *path, apteryx_watch_callback cb, void *priv);
+bool apteryx_watch (const char *path, apteryx_watch_callback cb, void *priv) __attribute__((nonnull (2)));
+
+/**
+ * UnWatch for changes in the path
+ * Supports *(wildcard) at the end of path for all children under this path
+ * Supports /(level) at the end of path for children only under this current path (one level down)
+ * Whenever a change occurs in a watched path, cb is called with the changed
+ * path and new value
+ * examples: (using libentity usage example)
+ * - apteryx_watch("/entity/zones/red/networks/*", network_updated, "red")
+ * @param path path to the value to be watched
+ * @param cb function to call when the value changes
+ * @return true on successful registration
+ */
+bool apteryx_unwatch (const char *path, apteryx_watch_callback cb) __attribute__((nonnull (2)));
 
 /**
  * Callback function to be called when a library users
@@ -180,7 +194,20 @@ typedef char* (*apteryx_provide_callback) (const char *path, void *priv);
  * @param priv something I want to be passed to my callback
  * @return true on successful registration
  */
-bool apteryx_provide (const char *path, apteryx_provide_callback cb, void *priv);
+bool apteryx_provide (const char *path, apteryx_provide_callback cb, void *priv) __attribute__((nonnull (2)));
+
+/**
+ * UnProvide a value that can be read on demand
+ * Whenever a get is performed on the given path/key, callback is called to get the value
+ * No *(wildcard)s are supported
+ * examples: (using contrived usage example)
+ * - apteryx_provide ("/hw/interfaces/port1.0.1/counters/tx", port_tx_counters, "port1.0.1")
+ * @param path path to the value that others will request
+ * @param cb function to be called if others request the value
+ * @return true on successful registration
+ */
+bool apteryx_unprovide (const char *path, apteryx_provide_callback cb) __attribute__((nonnull (2)));
+
 
 
 /**

--- a/apteryx.proto
+++ b/apteryx.proto
@@ -63,7 +63,9 @@ service server
     rpc get (Get) returns (GetResult);
     rpc search (Search) returns (SearchResult);
     rpc watch (Watch) returns (OKResult);
+    rpc unwatch (Watch) returns (OKResult);
     rpc provide (Provide) returns (OKResult);
+    rpc unprovide (Provide) returns (OKResult);
     rpc prune (Prune) returns (OKResult);
     rpc get_timestamp (Get) returns (GetTimeStampResult);
 }

--- a/internal.h
+++ b/internal.h
@@ -108,12 +108,16 @@ typedef struct _counters_t
     uint32_t search_invalid;
     uint32_t watch;
     uint32_t watch_invalid;
+    uint32_t unwatch;
+    uint32_t unwatch_invalid;
     uint32_t watched;
     uint32_t watched_no_match;
     uint32_t watched_no_handler;
     uint32_t watched_timeout;
     uint32_t provide;
     uint32_t provide_invalid;
+    uint32_t unprovide;
+    uint32_t unprovide_invalid;
     uint32_t provided;
     uint32_t provided_no_handler;
     uint32_t prune;


### PR DESCRIPTION
The callback function is now treated as part of the unique key
for watch and provide callbacks.
This means that watch (path, func1, ...) is distinct from
watch (path, my_func, ..) and both can co-exist in the same process
(previously whichever was later would override the earlier one)

This also now requires unwatch (path, func1) explicitly
rather than watch (path, NULL)
none of watch, unwatch, provide, unprovide will accept NULL as
the callback function anymore.